### PR TITLE
fix: Standardize all button heights to 56px for consistent UX

### DIFF
--- a/src/components/timer/timer-controls.tsx
+++ b/src/components/timer/timer-controls.tsx
@@ -135,7 +135,7 @@ export function TimerControls({ timer, className }: TimerControlsProps) {
               onClick={config.primary.action}
               disabled={!timer.isReady}
               className={cn(
-                'w-full h-14 text-base font-bold',  // Larger for single button (56px)
+                'w-full h-14 text-base font-bold',  // Larger 56px height
                 'text-white rounded-lg',
                 config.primary.color,
                 'shadow-lg hover:shadow-xl',
@@ -174,7 +174,7 @@ export function TimerControls({ timer, className }: TimerControlsProps) {
                 onClick={config.primary.action}
                 disabled={!timer.isReady}
                 className={cn(
-                  'w-full h-12 text-sm font-semibold',  // 48px for accessibility
+                  'w-full h-14 text-sm font-semibold',  // Larger 56px height
                   'text-white rounded-lg',
                   config.primary.color,
                   'shadow-lg hover:shadow-xl',
@@ -193,7 +193,7 @@ export function TimerControls({ timer, className }: TimerControlsProps) {
                   <div className="absolute inset-0 bg-gradient-to-t from-white/0 to-white/10 opacity-0 group-hover:opacity-100 transition-opacity duration-200" />
                   
                   {/* Button content */}
-                  <PrimaryIcon className="w-4 h-4 mr-2" />
+                  <PrimaryIcon className="w-5 h-5 mr-2" />
                   {config.primary.label}
                 </motion.button>
               </Button>
@@ -212,14 +212,14 @@ export function TimerControls({ timer, className }: TimerControlsProps) {
                   onClick={config.secondary.action}
                   variant="outline"
                   className={cn(
-                    'w-full h-12 rounded-lg text-sm font-medium',  // 48px for accessibility
+                    'w-full h-14 rounded-lg text-sm font-medium',  // Larger 56px height
                     'glass border-slate-600/50',
                     'hover:bg-red-900/40 hover:border-red-500/50',
                     'text-slate-200 hover:text-white',
                     'transition-all duration-200 ease-out shadow-md'
                   )}
                 >
-                  <Square className="w-3.5 h-3.5 mr-1.5" />
+                  <Square className="w-4 h-4 mr-2" />
                   {config.secondary.label}
                 </Button>
               )}


### PR DESCRIPTION
## Summary
- ✅ **Fixed button height inconsistency** across all timer states
- 📏 **Standardized to 56px (h-14)** for all control buttons  
- 🎯 **Improved touch targets** for better mobile accessibility
- 🎨 **Enhanced visual consistency** across the UI

## Problem Solved
The Start button was previously larger (56px) than the Pause/Resume/Stop buttons (48px), creating an inconsistent visual experience when transitioning between timer states.

## Changes Made
1. **Updated all button heights to h-14 (56px)**:
   - Single buttons (Start/Restart): Already h-14, kept consistent
   - Split layout primary buttons (Pause/Resume): Changed from h-12 to h-14
   - Split layout secondary button (Stop): Changed from h-12 to h-14

2. **Adjusted icon sizes for proper proportion**:
   - Primary button icons: w-5 h-5 for better visual balance
   - Secondary button icon: w-4 h-4 for consistency

## Testing Results
✅ **All states tested successfully**:
- **IDLE state**: Start button at 56px height
- **RUNNING state**: Pause (70%) and Stop (30%) buttons at 56px height
- **PAUSED state**: Resume (70%) and Stop (30%) buttons at 56px height
- **COMPLETED state**: Restart button at 56px height

## Visual Comparison
### Before
- Start: 56px
- Pause/Resume: 48px  
- Stop: 48px
- **Result**: Jarring visual transition between states

### After
- Start: 56px
- Pause/Resume: 56px
- Stop: 56px
- **Result**: Smooth, consistent visual experience

## Benefits
- 🎯 **Better accessibility**: Larger touch targets for all buttons
- 👁️ **Visual harmony**: No jarring size changes during state transitions
- 📱 **Mobile-friendly**: Easier to tap on mobile devices
- 🎨 **Professional appearance**: Consistent sizing improves overall UI quality

🤖 Generated with [Claude Code](https://claude.ai/code)